### PR TITLE
speed up gymnasium loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bazel-*
 __pycache__
+uv.lock

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -729,7 +729,7 @@
         "bzlTransitiveDigest": "h3l5yNW8eXVHIXFfZ1vECDJPLlSAOWTlWDCGnLT9mRw=",
         "usagesDigest": "T0fL24tE1b+5kwPNF/9I8bAf12j/qnhoQArq5gR2sIA=",
         "recordedFileInputs": {
-          "@@//requirements_linux_x86_64.txt": "23f9bb7c0ca9c2ccf22a05917dfdfacbeba5f3b010a6f3762e1c77174df1237e",
+          "@@//requirements_linux_x86_64.txt": "861139a90b89881fdf5b9c63594779663b16bcc7f6d8b6bf99abb5d679a171d7",
           "@@//tools/requirements_basedpyright.txt": "c4bc0a17780fc1e7a7b3ffa4549677e37af6334f890a97eb7931249cf438a286",
           "@@protobuf+//python/requirements.txt": "983be60d3cec4b319dcab6d48aeb3f5b2f7c3350f26b3a9e97486c37967c73c5",
           "@@rules_fuzzing+//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
@@ -1445,6 +1445,19 @@
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "pypi_312",
               "requirement": "pytest==8.3.4 --hash=sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6 --hash=sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"
+            }
+          },
+          "pypi_312_pytest_repeat": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
+              "repo": "pypi_312",
+              "requirement": "pytest-repeat==0.9.3 --hash=sha256:26ab2df18226af9d5ce441c858f273121e92ff55f5bb311d25755b8d7abdd8ed --hash=sha256:ffd3836dfcd67bb270bec648b330e20be37d2966448c4148c4092d1e8aba8185"
             }
           },
           "pypi_312_python_dateutil": {
@@ -4188,6 +4201,7 @@
                 "pygments": "{\"pypi_312_pygments\":[{\"version\":\"3.12\"}]}",
                 "pyparsing": "{\"pypi_312_pyparsing\":[{\"version\":\"3.12\"}]}",
                 "pytest": "{\"pypi_312_pytest\":[{\"version\":\"3.12\"}]}",
+                "pytest_repeat": "{\"pypi_312_pytest_repeat\":[{\"version\":\"3.12\"}]}",
                 "python_dateutil": "{\"pypi_312_python_dateutil\":[{\"version\":\"3.12\"}]}",
                 "pytz": "{\"pypi_312_pytz\":[{\"version\":\"3.12\"}]}",
                 "pyyaml": "{\"pypi_312_pyyaml\":[{\"version\":\"3.12\"}]}",
@@ -4255,6 +4269,7 @@
                 "pygments",
                 "pyparsing",
                 "pytest",
+                "pytest_repeat",
                 "python_dateutil",
                 "pytz",
                 "pyyaml",

--- a/earl/agents/simple_policy_gradient/BUILD.bazel
+++ b/earl/agents/simple_policy_gradient/BUILD.bazel
@@ -4,6 +4,7 @@ load("//tools/py_test:py_test.bzl", "py_test")
 py_library(
     name = "simple_policy_gradient",
     srcs = ["simple_policy_gradient.py"],
+    visibility = ["//visibility:public"],
     deps = [
         "//earl:core",
         "@pypi//equinox",

--- a/earl/environment_loop/BUILD.bazel
+++ b/earl/environment_loop/BUILD.bazel
@@ -62,6 +62,7 @@ py_test(
         "//earl:core",
         "//earl:metric_key",
         "//earl/agents/random_agent",
+        "//earl/agents/simple_policy_gradient",
         "//earl/utils:prng",
         "@pypi//gymnasium",
         "@pypi//gymnax",

--- a/earl/environment_loop/gymnasium_loop.py
+++ b/earl/environment_loop/gymnasium_loop.py
@@ -20,6 +20,17 @@ from jax_loop_utils.metric_writers.interface import MetricWriter
 from jaxtyping import PRNGKeyArray, PyTree, Scalar
 from tqdm import tqdm
 
+try:
+  import nvtx  # pyright: ignore[reportMissingImports]
+
+  nvtx_annotate = nvtx.annotate  # pyright: ignore[reportAssignmentType]
+except ImportError:
+
+  @contextlib.contextmanager
+  def nvtx_annotate(message: str):
+    yield
+
+
 from earl.core import (
   Agent,
   AgentState,
@@ -494,19 +505,21 @@ class GymnasiumLoop:
     agent_step = self._agent.step(agent_state_for_step, inp.env_step)
 
     for _ in range(num_steps):
-      # First: use the action from the previous agent.step to step the env.
-      obs, reward, done, trunc, info = self._env.step(np.array(agent_step.action))
-      # Convert results to JAX arrays and combine done and truncation.
-      obs = jnp.array(obs)
-      reward = jnp.array(reward)
-      done = jnp.array(done | trunc)
+      with nvtx_annotate("inference loop body"):
+        with nvtx_annotate("env.step"):
+          # First: use the action from the previous agent.step to step the env.
+          obs, reward, done, trunc, info = self._env.step(np.array(agent_step.action))
+        # Convert results to JAX arrays and combine done and truncation.
+        obs = jnp.array(obs)
+        reward = jnp.array(reward)
+        done = jnp.array(done | trunc)
 
-      # Now combine agent step and bookkeeping in a single jitted call.
-      agent_step, inp = self._agent_step_and_bookkeeping(
-        (agent_state, obs, reward, done, key), inp, agent_step
-      )
-      trajectory.append(inp.env_step)
-      step_infos.append(info)
+        with nvtx_annotate("agent_step_and_bookkeeping"):
+          agent_step, inp = self._agent_step_and_bookkeeping(
+            (agent_state, obs, reward, done, key), inp, agent_step
+          )
+        trajectory.append(inp.env_step)
+        step_infos.append(info)
 
     final_carry = inp
     agent_state = dataclasses.replace(agent_state, step=final_carry.step_state)

--- a/earl/environment_loop/gymnasium_loop.py
+++ b/earl/environment_loop/gymnasium_loop.py
@@ -495,10 +495,10 @@ class GymnasiumLoop:
         trajectory.append(env_step)
         step_infos.append(info)
 
-    metrics, trajectory_stacked, step_infos_stacked = self._inference_cycle_bookkeeping(
-      trajectory=trajectory,
-      step_infos=step_infos,
-    )
+    metrics, trajectory_stacked = self._inference_cycle_bookkeeping(trajectory=trajectory)
+
+    with jax.default_device(jax.devices("cpu")[0]):
+      step_infos_stacked = typing.cast(dict[typing.Any, typing.Any], _stack_leaves(step_infos))
     return CycleResult(
       agent_state,
       # not really the env state in any meaningful way, but we need to pass something
@@ -515,7 +515,6 @@ class GymnasiumLoop:
     """Computes metrics."""
     trajectory_stacked = _stack_leaves(trajectory)
 
-    # Calculate episode steps and completion metrics using array operations
     # Shape: (num_envs, num_steps)
     completed_episodes = trajectory_stacked.new_episode
     # Shape: (num_envs,)
@@ -529,7 +528,6 @@ class GymnasiumLoop:
       step_indices[None, :] * completed_episodes, axis=1, dtype=jnp.uint32
     )
 
-    # Calculate action counts
     if isinstance(self._action_space, Discrete):
       one_hot_actions = jax.nn.one_hot(
         trajectory_stacked.prev_action,
@@ -540,10 +538,8 @@ class GymnasiumLoop:
     else:
       action_counts = jnp.array(0, dtype=jnp.uint32)
 
-    # Calculate reward metrics
     total_reward = jnp.sum(trajectory_stacked.reward)
 
-    # Calculate mean episode length for complete episodes
     complete_episode_length_mean = jnp.where(
       complete_episode_count > 0,
       complete_episode_length_sum / complete_episode_count,
@@ -551,7 +547,6 @@ class GymnasiumLoop:
     )
     assert isinstance(complete_episode_length_mean, jax.Array)
 
-    # Prepare metrics dictionary
     metrics: ArrayMetrics = {
       MetricKey.COMPLETE_EPISODE_LENGTH_MEAN: jnp.mean(complete_episode_length_mean),
       MetricKey.NUM_ENVS_THAT_DID_NOT_COMPLETE: jnp.sum(complete_episode_count == 0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ classifiers = [
 keywords = ["Equinox", "JAX", "Reinforcement Learning"]
 
 [project.optional-dependencies]
-test = ["coverage>=7.0.0", "pytest>=8.0.0"]
+cuda = ["jax[cuda12]>=0.4.0", "nvtx>=0.2.10"]
+test = ["coverage>=7.0.0", "pytest>=8.0.0", "pytest-repeat==0.9.3"]
+
 
 [project.urls]
 Homepage = "http://github.com/garymm/earl"

--- a/requirements_linux_x86_64.txt
+++ b/requirements_linux_x86_64.txt
@@ -768,6 +768,12 @@ pyparsing==3.2.1 \
 pytest==8.3.4 \
     --hash=sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6 \
     --hash=sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761
+    # via
+    #   earl (pyproject.toml)
+    #   pytest-repeat
+pytest-repeat==0.9.3 \
+    --hash=sha256:26ab2df18226af9d5ce441c858f273121e92ff55f5bb311d25755b8d7abdd8ed \
+    --hash=sha256:ffd3836dfcd67bb270bec648b330e20be37d2966448c4148c4092d1e8aba8185
     # via earl (pyproject.toml)
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \


### PR DESCRIPTION
On H100:

➜ pytest  -s earl/environment_loop/test_gymnasium_loop.py::test_benchmark_gymnasium_inference

Steps per second: 6485.668245019974 

Before this PR:

Steps per second: 5410.341062565512

For the record, before 1951eae27d383fe1f20ac74621745e2d6b8017b7:

Steps per second: 3699.1313545546486

Pretty good speedups!